### PR TITLE
Prevents System Cards to take full width, which looks weird

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -123,6 +123,7 @@ a:active {
 
 .system-operational:last-child {
   margin-right: 0;
+  max-width: 50%;
 }
 
 .system-status-badge {
@@ -172,7 +173,7 @@ a:active {
   max-width: 300px;
   text-align: center;
   font-weight: 500;
-  color: #009A8D; /*Switch to appropriate color*/
+  color: #009A8D;
 }
 
 .system-check-ok img {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-statuskit/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->
It looks weird when you have an orphan card system element taking up full width. Now it's capped at 50%.

**- Test plan**

![screenshot 2016-11-22 09 48 14](https://cloud.githubusercontent.com/assets/2281080/20535213/d22b775e-b098-11e6-824c-3bc1817a5664.png)

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Layout Tweak


