### PR TITLE
Fix #25

### DIFF
--- a/site/layouts/index.html
+++ b/site/layouts/index.html
@@ -1,6 +1,6 @@
 {{ partial "header" . }}
 
-{{ $incidents := where .Site.Pages.ByDate.Reverse "Section" "incidents" }}
+{{ $incidents := where .Site.RegularPages.ByDate.Reverse "Section" "incidents" }}
 {{ $active := where $incidents "Params.resolved" "!=" true }}
 
 {{ partial "systems" (dict "content" . "incidents" $active) }}

--- a/site/layouts/partials/incident.html
+++ b/site/layouts/partials/incident.html
@@ -6,9 +6,10 @@
   <div class="incident-description">
     {{- .Content -}}
   </div>
-  {{- $alert := index .Site.Data.severity.alerts .Params.severity -}}
+  {{- $severity := .Params.severity  | default "under-maintenance" -}}
+  {{- $alert := index .Site.Data.severity.alerts $severity -}}
 
   <p class="incident-status color-{{ $alert }}">
-    {{ index .Site.Data.severity.descriptions .Params.severity }}
+    {{ index .Site.Data.severity.descriptions $severity }}
   </p>
 </div>


### PR DESCRIPTION
Use `.Site.RegularPages` instead of `.Site.Pages` to fix #25.

Guard agains `.Params` being null with a default severity level.

## TIL
`Site.Pages`
> array of all content ordered by Date with the newest first. This array contains only the pages in the current language.

`.Site.RegularPages`
> da shortcut to the regular page collection. .Site.RegularPages is equivalent to where .Site.Pages "Kind" "page".