### PR TITLE
Don't show fixed 'days since' by default.

### DIFF
--- a/site/layouts/partials/all-clear.html
+++ b/site/layouts/partials/all-clear.html
@@ -2,7 +2,7 @@
   <img src="/images/icon-large-ok.svg" />
   {{ with .Date }}
     {{ $latestDate := dateFormat "2006-01-02T15:04:05" .}}
-    <p id="days-since-latest" data-latest-incident-date="{{ $latestDate }}">48+ days since last incident</p>
+    <p id="days-since-latest" data-latest-incident-date="{{ $latestDate }}">Last incident: {{ .Format "02 Jan 2006 15:04 MST" }}</p>
   {{ else }}
     <p>No incidents so far, all is good</p>
   {{ end }}


### PR DESCRIPTION
If JavaScript doesn't run for whatever reason, the site was showing a fixed "48+ days since last incident", which could well be incorrect. Instead, use the actual date of the last incident so it will show something correct in such a situation.
(I maintained the same date format as used elsewhere, would it be acceptable if I made that a configuration option for everywhere?)

![](https://c2.staticflickr.com/6/5031/7221851574_35e79b2a32_n.jpg)
