### PR TITLE
Only show one system status with >1 incidents.

### DIFF
--- a/site/data/severity.toml
+++ b/site/data/severity.toml
@@ -11,3 +11,17 @@
   degraded-performance = "warning"
   partial-outage = "warning"
   major-outage = "danger"
+
+[levels]
+  0 = "ok"
+  1 = "under-maintenance"
+  2 = "degraded-performance"
+  3 = "partial-outage"
+  4 = "major-outage"
+
+[levels_reverse]
+  ok = 0
+  under-maintenance = 1
+  degraded-performance = 2
+  partial-outage = 3
+  major-outage = 4

--- a/site/layouts/partials/systems.html
+++ b/site/layouts/partials/systems.html
@@ -9,15 +9,19 @@
     <div class="card">
       {{- $name -}}
       {{ if $.incidents }}
+        {{ $.content.Scratch.Set "max" 0 }}
         {{ range $.incidents }}
           {{ if in .Params.affectedsystems $name }}
-            {{ $alert := index .Site.Data.severity.alerts .Params.severity }}
-            {{ $desc := index .Site.Data.severity.descriptions .Params.severity  }}
-            {{ partial "status-badge" (dict "alert" $alert "description" $desc) }}
-          {{ else }}
-            {{ partial "status-badge" (dict "alert" $okAlert "description" $okDesc) }}
+            {{ $level := index .Site.Data.severity.levels_reverse .Params.severity }}
+            {{ if gt $level ($.content.Scratch.Get "max") }}
+              {{ $.content.Scratch.Set "max" $level }}
+            {{ end }}
           {{ end }}
         {{ end }}
+        {{ $severity := index $.content.Site.Data.severity.levels (string ($.content.Scratch.Get "max")) }}
+        {{ $alert := index $.content.Site.Data.severity.alerts $severity }}
+        {{ $desc := index $.content.Site.Data.severity.descriptions $severity  }}
+        {{ partial "status-badge" (dict "alert" $alert "description" $desc) }}
       {{ else }}
         {{ partial "status-badge" (dict "alert" $okAlert "description" $okDesc) }}
       {{ end }}


### PR DESCRIPTION
This stops the duplication of/incorrect system statuses when there are multiople active incidents. It works out the maximum level to display. Fixes #32.

I don't really know Hugo at all, but I couldn't see any way to do this without having both ways of the levels lookup. This does work, but hopefully you might know a nicer way!

![](https://c2.staticflickr.com/4/3623/3404664045_5da8a79f4b.jpg)
