### PR TITLE
Fix lint errors.

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -160,15 +160,15 @@ gulp.task("new-incident", (cb) => {
 });
 
 function getPlatform(platform) {
-    switch (platform) {
-      case "win32":
-      case "win64": {
-        return "windows";
-      }
-      default: {
-        return platform
-      }
+  switch (platform) {
+    case "win32":
+    case "win64": {
+      return "windows";
     }
+    default: {
+      return platform;
+    }
+  }
 }
 
 function generateFrontMatter(frontMatter, answers) {


### PR DESCRIPTION
Tiny PR to fix the output of `npm run lint`.